### PR TITLE
Fix js file reference

### DIFF
--- a/example-thing.php
+++ b/example-thing.php
@@ -27,7 +27,7 @@ class ExampleThing {
 
 	function admin_enqueue_scripts() {
 		add_action( 'admin_footer', array( $this, 'print_templates' ) );
-		$src = WP_PLUGIN_URL . "/example-thing/example-thing.js";
+		$src = plugins_url( 'example-thing.js', __FILE__ );
 		wp_enqueue_script( 'example-thing', $src, array( 'mce-view' ), false, 1 );
 	}
 


### PR DESCRIPTION
Using `plugins_url()` will ensure the correct absolute URL for the js file.  The existing method doesn't work properly when the plugin directory name isn't `/example-thing/`.  ( I downloaded a .zip from Git and the plugin directory was called `/example-thing-master/`. )
